### PR TITLE
Replace print statements with logger

### DIFF
--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import sys
@@ -7,13 +5,18 @@ import sys
 import yaml
 
 from constants import *
+from logger import get_logger
 from response import build_response_payload
 from session import Session
+
+
+_logger = get_logger()
 
 
 def _load_state_machine(filename):
     with open(filename, 'r') as fh:
         return yaml.load(fh)
+
 
 
 class LazySusanApp(object):
@@ -60,13 +63,13 @@ class LazySusanApp(object):
         except KeyError:
             pass
 
-        print(event)
+        _logger.error(event)
         raise Exception("Could not find userId in lambda event")
 
 
     def build_response(self, request, session, intent, context, user_id):
         state = session.get_state()
-        print("Current state: %s" % (state, ))
+        _logger.info("Current state: %s" % (state, ))
 
         # Determine what our response is by looking up our current state followed by
         # the intent in the request. Each state must define a "default" branch.
@@ -112,7 +115,7 @@ class LazySusanApp(object):
         :attr context: Lambda context
         """
         # Leave this in for logging
-        print("Event: %s" % (event, ))
+        _logger.info("Event: %s" % (event, ))
 
         request = event["request"]
         context = event.get("context")
@@ -127,5 +130,5 @@ class LazySusanApp(object):
         session.save()
 
         # Leave this in for logging
-        print("Response: %s" % (response, ))
+        _logger.info("Response: %s" % (response, ))
         return response

--- a/lazysusan/logger.py
+++ b/lazysusan/logger.py
@@ -1,0 +1,40 @@
+import logging
+import os
+
+
+_configured = False
+
+
+def _is_configured():
+    return _is_configured
+
+
+def _configure(level):
+    global _configured
+    if not _is_configured():
+        logging.basicConfig(format="[%(levelname)s] %(filename)s %(message)s", level=level)
+        _configured = True
+
+
+def get_level():
+    level = os.environ.get("LAZYSUSAN_LOG_LEVEL", "logging.WARN")
+    if not level.startswith("logging."):
+        level = logging.WARN
+    else:
+        level = eval(level)
+    return level
+
+
+def get_logger(name="LazySusan"):
+    """Return a named logger.
+
+    Note, this should be called one time per named logger.
+
+    """
+    level = get_level()
+    _configure(level)
+
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    return logger

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,50 @@
+import logging
+import pytest
+
+from mock import PropertyMock
+
+from lazysusan.logger import (
+    _configure,
+    get_level,
+    get_logger,
+)
+
+
+def test_get_level_default():
+    assert get_level() == logging.WARN
+
+
+def test_get_level_debug(mocker):
+    mocker.patch.dict("os.environ", {"LAZYSUSAN_LOG_LEVEL": "logging.DEBUG"})
+    assert get_level() == logging.DEBUG
+
+
+@pytest.fixture(params=("INVALID", "log.INFO", "logger.INFO", "loggingINFO"))
+def invalid_level(request):
+    yield request.param
+
+
+def test_get_level_invalid(mocker, invalid_level):
+    mocker.patch.dict("os.environ", {"LAZYSUSAN_LOG_LEVEL": invalid_level})
+    assert get_level() == logging.WARN
+
+
+def test_configure(mocker):
+    mock_config = mocker.patch("lazysusan.logger.logging.basicConfig")
+    mock_configured = mocker.patch("lazysusan.logger._is_configured")
+    mock_configured.return_value = False
+    _configure(logging.INFO)
+    assert mock_config.call_count == 1
+
+
+def test_configure_once(mocker):
+    mock_config = mocker.patch("lazysusan.logger.logging.basicConfig")
+
+    mock_configured = mocker.patch("lazysusan.logger._is_configured")
+    mock_configured.return_value = False
+    _configure(logging.INFO)
+
+    mock_configured.return_value = True
+    _configure(logging.INFO)
+    _configure(logging.INFO)
+    assert mock_config.call_count == 1


### PR DESCRIPTION
Why
---

- Use logger to allow for easier control on system output and debugging

This change addresses the need by
---------------------------------

- Add a simple wrapper around logger
- Lookup the log level as an environment variable, which allows developers to control how much or
  little log output they get.
- Make the logger way more complicated than it could be so that we can better test it

Next Steps
----------

- None