### PR TITLE
Handle Cookie Sessions

### DIFF
--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -100,7 +100,7 @@ class LazySusanApp(object):
             offset = session.get_audio_offset()
             response['directives'][0]['audioItem']['stream']['offsetInMilliseconds'] = offset
 
-        response_payload = build_response_payload(response)
+        response_payload = build_response_payload(response, session.get_state_params())
 
         return response_payload
 
@@ -122,7 +122,7 @@ class LazySusanApp(object):
 
         user_id = LazySusanApp.get_user_id_from_event(event)
 
-        session = Session(user_id, self.__session_key)
+        session = Session(user_id, self.__session_key, event)
 
         intent = LazySusanApp.get_intent_from_request(request)
         response = self.build_response(request, session, intent, context, user_id)

--- a/lazysusan/response.py
+++ b/lazysusan/response.py
@@ -1,4 +1,4 @@
-def build_response_payload(speechlet_response):
+def build_response_payload(speechlet_response, state):
     """Build a valid Alexa response given a speechlet data structure.
 
     :attr speechlet_response: A data structure which conforms to the Alexa response type
@@ -6,6 +6,7 @@ def build_response_payload(speechlet_response):
 
     """
     return {
-        'version': '2.0',
-        'response': speechlet_response,
+        "version": "2.0",
+        "sessionAttributes": state,
+        "response": speechlet_response,
     }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -18,6 +18,37 @@ def test_get_backend_dynamodb(mocker):
     assert session._backend.__class__.__name__ == "DynamoDB"
 
 
+def test_get_backend_cookie(mocker):
+    mocker.patch.dict("os.environ", {"LAZYSUSAN_SESSION_STORAGE_BACKEND": "cookie"})
+    session = Session(user_id="dynamodb", session_key="THRIVE_STATE", event={"session": {"attributes": {}}})
+    assert session._backend.__class__.__name__ == "Memory"
+
+
+def test_get_backend_cookie(mocker):
+    event = {
+        "session": {
+            "attributes": {
+                "THRIVE_STATE": "foobar"
+            }
+        }
+    }
+    mocker.patch.dict("os.environ", {"LAZYSUSAN_SESSION_STORAGE_BACKEND": "cookie"})
+    session = Session(user_id="dynamodb", session_key="THRIVE_STATE", event=event)
+    assert session.get_state() == "foobar"
+
+
+def test_get_backend_cookie_bad_event(mocker):
+    mocker.patch.dict("os.environ", {"LAZYSUSAN_SESSION_STORAGE_BACKEND": "cookie"})
+    session = Session(user_id="dynamodb", session_key="THRIVE_STATE", event=("hi", "mom"))
+    assert session._backend.__class__.__name__ == "Memory"
+
+
+def test_get_backend_cookie_empty_event(mocker):
+    mocker.patch.dict("os.environ", {"LAZYSUSAN_SESSION_STORAGE_BACKEND": "cookie"})
+    session = Session(user_id="dynamodb", session_key="THRIVE_STATE", event={"session": {}})
+    assert session._backend.__class__.__name__ == "Memory"
+
+
 def test_get_state_default(session):
     assert session.get_state() == "initialState"
 


### PR DESCRIPTION
Why
---

- At some level we need the ability to handle sessions but they don't
need to be persisted in dynamodb.

This change addresses the need by
---------------------------------

- Store session information in the sessionAttributes response and
request chain.

Next Steps
----------

- Create a new app that utilizes the cookie session storage.