### PR TITLE
Clear session and create Request wrapper

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,20 @@
+[MASTER]
+
+[BASIC]
+
+good-names = fh,_configured,_logger
+
+[DESIGN]
+
+max-args = 6
+
+[FORMAT]
+
+max-line-length = 100
+
+[MESSAGES CONTROL]
+
+disable = missing-docstring, wildcard-import
+
+[REPORTS]
+include-ids = yes

--- a/examples/age_difference/Age/callbacks/__init__.py
+++ b/examples/age_difference/Age/callbacks/__init__.py
@@ -16,7 +16,7 @@ DOB_KEY = "LAST_DOB"
 def calc_difference(request, session, intent, context, user_id, state_machine):
     log = get_logger()
 
-    date = get_slot_value(request, "dob")
+    date = request.get_slot_value("dob")
     if not date:
         log.error("Could  not find date in slots")
         return "goodBye"

--- a/lazysusan/__init__.py
+++ b/lazysusan/__init__.py
@@ -1,1 +1,1 @@
-from app import LazySusanApp
+from .app import LazySusanApp

--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -115,6 +115,8 @@ class LazySusanApp(object):
         user_id = LazySusanApp.get_user_id_from_event(event)
 
         session = Session(user_id, self.__session_key, event)
+        if session.is_expired:
+            session.clear()
 
         response = self.build_response(request, session, request.intent_name, context, user_id)
 

--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -1,14 +1,9 @@
-import json
-import os
-import sys
-
 import yaml
 
-from constants import *
-from logger import get_logger
-from request import Request
-from response import build_response_payload
-from session import Session
+from .logger import get_logger
+from .request import Request
+from .response import build_response_payload
+from .session import Session
 
 
 _logger = get_logger()
@@ -55,7 +50,7 @@ class LazySusanApp(object):
 
     def build_response(self, request, session, intent_name, context, user_id):
         state = session.get_state()
-        _logger.info("Current state: %s" % (state, ))
+        _logger.info("Current state: %s", state)
 
         # Determine what our response is by looking up our current state followed by
         # the intent_name in the request. Each state must define a "default" branch.
@@ -66,8 +61,8 @@ class LazySusanApp(object):
         except KeyError:
             branch = branches["default"]
 
-        # Allow us to specifically short-circuit and *not* return a request. This is due
-        # to certain cases where a callback from Alexa does not accept any type of response. Typically
+        # Allow us to specifically short-circuit and *not* return a request. This is due to
+        # certain cases where a callback from Alexa does not accept any type of response. Typically
         # this is during audio playback for long-form audio.
         if branch is None:
             session.update_audio_state(context)
@@ -76,7 +71,7 @@ class LazySusanApp(object):
         # now branch is the next state
         if callable(branch):
             branch_or_response = branch(request, session, intent_name, context, user_id,
-                    self.__state_machine)
+                                        self.__state_machine)
             if isinstance(branch_or_response, dict):
                 return branch_or_response
             else:
@@ -97,7 +92,7 @@ class LazySusanApp(object):
         return response_payload
 
 
-    def handle(self, event, lambda_context=None):
+    def handle(self, event, lambda_context=None): #pylint: disable=locally-disabled,unused-argument
         """Main handler which receives initial request from Lambda.
 
         Route the incoming request based on type LaunchRequest, IntentRequest, etc.).
@@ -107,7 +102,7 @@ class LazySusanApp(object):
         :attr context: Lambda context
         """
         # Leave this in for logging
-        _logger.info("Event: %s" % (event, ))
+        _logger.info("Event: %s", event)
 
         request = Request(event["request"])
         context = event.get("context")
@@ -123,5 +118,5 @@ class LazySusanApp(object):
         session.save()
 
         # Leave this in for logging
-        _logger.info("Response: %s" % (response, ))
+        _logger.info("Response: %s", response)
         return response

--- a/lazysusan/logger.py
+++ b/lazysusan/logger.py
@@ -10,7 +10,7 @@ def _is_configured():
 
 
 def _configure(level):
-    global _configured
+    global _configured #pylint: disable=I0011,global-statement
     if not _is_configured():
         logging.basicConfig(format="[%(levelname)s] %(filename)s %(message)s", level=level)
         _configured = True
@@ -21,7 +21,7 @@ def get_level():
     if not level.startswith("logging."):
         level = logging.WARN
     else:
-        level = eval(level)
+        level = eval(level) #pylint: disable=I0011,eval-used
     return level
 
 

--- a/lazysusan/persistence.py
+++ b/lazysusan/persistence.py
@@ -1,10 +1,11 @@
-import boto3
 import os
+import boto3
 
 
 class Memory(dict):
 
     def __init__(self, *args, **kwargs):
+        super(Memory, self).__init__(*args, **kwargs)
         self.update(*args, **kwargs)
 
     def connect(self, **kwargs):
@@ -17,7 +18,9 @@ class Memory(dict):
 class DynamoDB(dict):
 
     def __init__(self, *args, **kwargs):
+        super(DynamoDB, self).__init__(*args, **kwargs)
         self._db = None
+        self._table = None
 
     def connect(self, **kwargs):
         table_name = os.environ["LAZYSUSAN_SESSION_DYNAMODB_TABLE_NAME"]

--- a/lazysusan/request.py
+++ b/lazysusan/request.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+
+class Request(object):
+
+    def __init__(self, request):
+        self._request = request
+
+    @property
+    def intent_name(self):
+        try:
+            return self._request["intent"]["name"]
+        except KeyError:
+            pass
+
+        try:
+            return self._request["type"]
+        except KeyError:
+            pass
+
+        raise Exception("Could not find appropriate callback for intent: %s" % (self._request, ))
+
+    @property
+    def raw(self):
+        return self._request
+
+    @property
+    def request_type(self):
+        return self._request["type"]
+
+    @property
+    def timestamp(self):
+        return datetime.strptime(self._request["timestamp"], "%Y-%m-%dT%H:%M:%SZ")
+
+    def get_slot_value(self, slot_name):
+        return self._request["intent"]["slots"][slot_name]["value"]

--- a/lazysusan/session.py
+++ b/lazysusan/session.py
@@ -1,8 +1,6 @@
 import os
-import persistence
-
-
 from datetime import datetime
+import persistence #pylint: disable=I0011,relative-import
 
 
 class Session(object):
@@ -55,7 +53,7 @@ class Session(object):
                 memory = persistence.Memory()
                 memory.update(self.__event["session"]["attributes"])
                 return memory
-            except (KeyError, TypeError), err:
+            except (KeyError, TypeError):
                 pass
 
         return persistence.Memory()
@@ -69,14 +67,14 @@ class Session(object):
     def get_audio_offset(self):
         try:
             return self._backend["AudioPlayer"]["offsetInMilliseconds"]
-        except (KeyError, TypeError), err:
+        except (KeyError, TypeError):
             return 0
 
     def update_audio_state(self, context):
         # context may be None in certain requests. In that case we may just pass
         try:
             self._backend["AudioPlayer"] = context["AudioPlayer"]
-        except (KeyError, TypeError), err:
+        except (KeyError, TypeError):
             pass
 
     def update_state(self, state, context):

--- a/lazysusan/session.py
+++ b/lazysusan/session.py
@@ -41,6 +41,10 @@ class Session(object):
     def set(self, key, val):
         self._backend[key] = val
 
+    def clear(self):
+        self._backend.clear()
+        self._backend["userId"] = self._user_id
+
     def get_backend(self):
         backend = os.environ.get("LAZYSUSAN_SESSION_STORAGE_BACKEND", "dynamodb")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,12 @@ def get_state(mocker):
 
 @pytest.fixture()
 def mock_session(mocker):
+    session = mocker.patch("lazysusan.app.Session")
+    return session.return_value
+
+
+@pytest.fixture()
+def mock_session_backend(mocker):
     mock_persistence = mocker.patch("lazysusan.persistence.Memory")
     backend = TestBackend()
     mock_persistence.return_value = backend

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,13 +6,6 @@ from lazysusan.app import LazySusanApp
 CWD = os.path.dirname(os.path.realpath(__file__))
 
 
-def test_get_intent_name_from_request_exception():
-    with pytest.raises(Exception) as err:
-        LazySusanApp.get_intent_name_from_request({})
-
-    assert "Could not find appropriate callback for intent" in str(err.value)
-
-
 def test_get_user_id_from_event_exception():
     with pytest.raises(Exception) as err:
         LazySusanApp.get_user_id_from_event({})

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,68 @@
+import pytest
+
+from datetime import datetime
+from lazysusan.request import Request
+
+
+@pytest.fixture()
+def alexa_request():
+    return {
+        "type": "IntentRequest",
+        "requestId": "bob",
+        "locale": "en-US",
+        "timestamp": "2016-12-08T20:34:09Z",
+        "intent": {
+            "name": "GotAnIntent",
+            "slots": {
+                "WhatSlot": {
+                    "name": "WhatSlot",
+                    "value": "ThisSlot",
+                    }
+                }
+            }
+    }
+
+
+@pytest.fixture()
+def launch_request():
+    return {
+        "type": "LaunchRequest",
+        "requestId": "bob",
+        "locale": "en-US",
+        "timestamp": "2016-12-08T20:34:09Z",
+    }
+
+
+def test_create_an_intent(alexa_request):
+    new_request = Request(alexa_request)
+    assert new_request._request == alexa_request
+
+
+def test_raw_request(alexa_request):
+    new_request = Request(alexa_request)
+    assert new_request.raw == alexa_request
+
+
+def test_request_timestamp(alexa_request):
+    new_request = Request(alexa_request)
+    assert new_request.timestamp == datetime(2016, 12, 8, 20, 34, 9)
+
+
+def test_request_with_bad_intent_name():
+    with pytest.raises(Exception):
+        Request({}).intent_name
+
+
+def test_request_type(alexa_request):
+    new_request = Request(alexa_request)
+    assert new_request.request_type == "IntentRequest"
+
+
+def test_launch_request_type(launch_request):
+    new_request = Request(launch_request)
+    assert new_request.request_type == "LaunchRequest"
+
+
+def test_get_slot_value(alexa_request):
+    new_request = Request(alexa_request)
+    assert new_request.get_slot_value("WhatSlot") == "ThisSlot"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -146,3 +146,9 @@ def test_is_expired_bad(session, mocker):
     mocker.patch.dict("os.environ", {"LAZYSUSAN_TTL_SECONDS": "abc1"})
     with pytest.raises(ValueError):
         session.is_expired
+
+
+def test_clear(session):
+    session._backend["barney"] = "rubble"
+    session.clear()
+    assert session._backend["userId"] == "testuser"


### PR DESCRIPTION
Why
---

- We were constantly having to index the dictionary to pull data out of the
  request. Therefore it made sense to create our own Request object to help
  keep the code base clean so certain values could be obtained super easily.
- In order to enforce TTL, we need a way to determine if the session is expired.
- When we've hit the session's TTL we need to ignore any saved state on launch

This change addresses the need by
---------------------------------

- Implement `Request` object/class
- In main handler, clear out the session state if the session has passed the TTL
- Always keep the `userId` key in the session as this is basically the
  primary key of the session.
- 100% code coverage