### PR TITLE
Pass Keyword Args to Callbacks

### DIFF
--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -70,8 +70,14 @@ class LazySusanApp(object):
 
         # now branch is the next state
         if callable(branch):
-            branch_or_response = branch(request, session, intent_name, context, user_id,
-                                        self.__state_machine)
+            branch_or_response = branch(
+                request=request,
+                session=session,
+                intent_name=intent_name,
+                context=context,
+                user_id=user_id,
+                state_machine=self.__state_machine
+            )
             if isinstance(branch_or_response, dict):
                 return branch_or_response
             else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='lazysusan',
     packages=find_packages(exclude=['tests', 'tests.*', 'examples', 'examples.*']),
-    version = '0.2',
+    version = '0.3',
     description = 'A library for authoring Alexa apps',
     author='Spartan Systems',
     author_email='sass@joinspartan.com',

--- a/tests/callbacks/__init__.py
+++ b/tests/callbacks/__init__.py
@@ -2,11 +2,11 @@ from lazysusan.helpers import build_response
 from lazysusan.response import build_response_payload
 
 
-def do_callback(request, session, intent, context, users_id, state_machine):
+def do_callback(**kwargs):
     return "callbackIntent"
 
 
-def do_dynamic_callback(request, session, intent, context, users_id, state_machine):
+def do_dynamic_callback(session=None, state_machine=None, **kwargs):
     msg = "this is some dynamic content"
     response_dict = build_response("goodbyeIntent", msg, state_machine)
     return build_response_payload(response_dict, session.get_state_params())


### PR DESCRIPTION
Why
---

- The callbacks need the ability to accept a wide array of values so
they have full access to all relevant data.

This change addresses the need by
---------------------------------

- Make the developer experience better by passing all of these values in
as keyword args.

Next Steps
----------

- Update the examples.