### PR TITLE
Fix Setting Last Request Time

### DIFF
--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -119,6 +119,8 @@ class LazySusanApp(object):
         if session.is_expired:
             session.clear()
 
+        session.last_request_time = request.timestamp
+
         response = self.build_response(request, session, request.intent_name, context, user_id)
 
         session.save()

--- a/lazysusan/constants.py
+++ b/lazysusan/constants.py
@@ -1,3 +1,0 @@
-INTENT_REQUEST = 'IntentRequest'
-LAUNCH_REQUEST = 'LaunchRequest'
-SESSION_ENDED_REQUEST = 'SessionEndedRequest'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='lazysusan',
     packages=find_packages(exclude=['tests', 'tests.*', 'examples', 'examples.*']),
-    version = '0.3',
+    version = '0.4',
     description = 'A library for authoring Alexa apps',
     author='Spartan Systems',
     author_email='sass@joinspartan.com',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -106,3 +106,9 @@ class TestInitialState(object):
         response = app.handle(launch_request)
         assert mock_session.clear.call_count == 1
         assert mock_session.save.call_count == 1
+
+    def test_session_last_request_time_is_set(self, app, mock_session_backend, launch_request):
+        launch_request["request"]["timestamp"] = "2000-01-01T00:00:00Z"
+        expected_dt = datetime(2000, 1, 1)
+        response = app.handle(launch_request)
+        assert mock_session_backend["LAST_REQUEST_TIME"] == expected_dt


### PR DESCRIPTION
Why
---

- We did everything but actually set the value.

This change addresses the need by
---------------------------------

- Set the last request time after determining if the session is expired.

Next Steps
----------

- Deploy.