### PR TITLE
Store String Value of Time

### DIFF
--- a/lazysusan/session.py
+++ b/lazysusan/session.py
@@ -27,10 +27,16 @@ class Session(object):
 
     @property
     def last_request_time(self):
-        return self.get("LAST_REQUEST_TIME", datetime.now())
+        timestamp = self.get("LAST_REQUEST_TIME")
+
+        if not timestamp:
+            return datetime.now()
+
+        return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
 
     @last_request_time.setter
     def last_request_time(self, timestamp):
+        timestamp = timestamp.replace(microsecond=0).isoformat()
         self.set("LAST_REQUEST_TIME", timestamp)
 
     def get(self, key, default=None):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='lazysusan',
     packages=find_packages(exclude=['tests', 'tests.*', 'examples', 'examples.*']),
-    version = '0.4',
+    version = '0.5',
     description = 'A library for authoring Alexa apps',
     author='Spartan Systems',
     author_email='sass@joinspartan.com',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -109,6 +109,6 @@ class TestInitialState(object):
 
     def test_session_last_request_time_is_set(self, app, mock_session_backend, launch_request):
         launch_request["request"]["timestamp"] = "2000-01-01T00:00:00Z"
-        expected_dt = datetime(2000, 1, 1)
+        expected_dt = datetime(2000, 1, 1).isoformat()
         response = app.handle(launch_request)
         assert mock_session_backend["LAST_REQUEST_TIME"] == expected_dt


### PR DESCRIPTION
Why
---

- The database doesn't like the python object.

This change addresses the need by
---------------------------------

- Converting the date to and from a string appropriately.

Next Steps
----------

- None