### PR TITLE
Add ability to conditionally skip state changes

### DIFF
--- a/lazysusan/session.py
+++ b/lazysusan/session.py
@@ -83,12 +83,11 @@ class Session(object):
         except (KeyError, TypeError):
             pass
 
-    def update_state(self, state, context):
+    def update_state(self, state):
         self._backend.update({
             self.__session_key: state,
             "userId": self._user_id,
         })
-        self.update_audio_state(context)
 
     def save(self):
         self._backend.save()

--- a/tests/states.yml
+++ b/tests/states.yml
@@ -45,6 +45,7 @@ goodbyeIntent:
   branches:
     default: initialState
 
+
 helloIntent:
   response:
     card:
@@ -56,7 +57,19 @@ helloIntent:
       text: hello
     shouldEndSession: True
   branches:
+    AudioPlayer.PlaybackNearlyFinished: nonState
     default: initialState
+
+nonState:
+  is_state: false
+  response:
+    outputSpeech:
+      type: PlainText
+      text: This isn't a state
+    shouldEndSession: True
+  branches:
+    LaunchRequest: initialState
+
 
 callbackIntent:
   response:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -66,6 +66,20 @@ class TestInitialState(object):
         response = app.handle(custom_intent)
         assert_response(response, "callbackIntent", mock_session_backend, self.EXPECTED_KEYS)
 
+    def test_cancel_intent_no_state_change(self, app, mock_session_backend,
+            playback_nearly_finished_request, get_state):
+        get_state.return_value = "helloIntent"
+        response = app.handle(playback_nearly_finished_request)
+
+        expected_audio_state = {
+            "playerActivity": "PLAYING",
+            "token": "test",
+            "offsetInMilliseconds": 41000,
+        }
+        assert "LAZYSUSAN_STATE" not in mock_session_backend
+        assert sorted(response["response"].keys()) == sorted(self.EXPECTED_KEYS)
+        assert mock_session_backend["AudioPlayer"] == expected_audio_state
+
     def test_dynamic_intent(self, app, mock_session_backend, dynamic_intent):
         response = app.handle(dynamic_intent)
         expected_msg = "this is some dynamic content"


### PR DESCRIPTION
Why
---

- We don't always need or want to change state when a request comes in
- When audio callbacks come in we often want to remain in our current
  state

This change addresses the need by
---------------------------------

- Adding a hook which looks for `is_state` boolean key in the yaml files
- When `is_state == False` only the audio state is updated

Next Steps
----------

- None