### PR TITLE
Fix/return empty json response

### DIFF
--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -58,7 +58,10 @@ class LazySusanApp(object):
         # this is during audio playback for long-form audio.
         if branch_name is None:
             session.update_audio_state(context)
-            return {}
+            # For states where alexa does not want a response, we need to exit without returning
+            # anything to prevent an Alexa platform error. As of this time, this has not been
+            # documented clearly by Amazon.
+            raise SystemExit
 
         # now branch_name is the next state
         if callable(branch_name):

--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -58,7 +58,7 @@ class LazySusanApp(object):
         # this is during audio playback for long-form audio.
         if branch_name is None:
             session.update_audio_state(context)
-            return
+            return {}
 
         # now branch_name is the next state
         if callable(branch_name):

--- a/lazysusan/app.py
+++ b/lazysusan/app.py
@@ -2,7 +2,10 @@ import yaml
 
 from .logger import get_logger
 from .request import Request
-from .response import build_response_payload
+from .response import (
+    build_empty_response,
+    build_response_payload,
+)
 from .session import Session
 
 
@@ -61,7 +64,7 @@ class LazySusanApp(object):
             # For states where alexa does not want a response, we need to exit without returning
             # anything to prevent an Alexa platform error. As of this time, this has not been
             # documented clearly by Amazon.
-            raise SystemExit
+            return build_empty_response()
 
         # now branch_name is the next state
         if callable(branch_name):

--- a/lazysusan/response.py
+++ b/lazysusan/response.py
@@ -1,3 +1,7 @@
+def build_empty_response():
+    return build_response_payload({"shouldEndSession": True}, {})
+
+
 def build_response_payload(speechlet_response, state):
     """Build a valid Alexa response given a speechlet data structure.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='lazysusan',
     packages=find_packages(exclude=['tests', 'tests.*', 'examples', 'examples.*']),
-    version = '0.5',
+    version = '0.6',
     description = 'A library for authoring Alexa apps',
     author='Spartan Systems',
     author_email='sass@joinspartan.com',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -101,17 +101,17 @@ class TestInitialState(object):
         assert response["response"]["directives"] == [expected]
 
     def test_playback_started(self, app, mock_session_backend, playback_started_request):
-        response = app.handle(playback_started_request)
-        assert response == {}
+        with pytest.raises(SystemExit):
+            app.handle(playback_started_request)
 
     def test_playback_nearly_finished(self, app, mock_session_backend,
             playback_nearly_finished_request):
-        response = app.handle(playback_nearly_finished_request)
-        assert response == {}
+        with pytest.raises(SystemExit):
+            app.handle(playback_nearly_finished_request)
 
     def test_playback_finished(self, app, mock_session_backend, playback_finished_request):
-        response = app.handle(playback_finished_request)
-        assert response == {}
+        with pytest.raises(SystemExit):
+            app.handle(playback_finished_request)
 
     def test_session_cleared_and_saved(self, app, mock_session, launch_request):
         mock_session.is_expired = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -101,17 +101,20 @@ class TestInitialState(object):
         assert response["response"]["directives"] == [expected]
 
     def test_playback_started(self, app, mock_session_backend, playback_started_request):
-        with pytest.raises(SystemExit):
-            app.handle(playback_started_request)
+        response = app.handle(playback_started_request)
+        assert response.get("sessionAttributes") == {}
+        assert response.get("response") == {"shouldEndSession": True}
 
     def test_playback_nearly_finished(self, app, mock_session_backend,
             playback_nearly_finished_request):
-        with pytest.raises(SystemExit):
-            app.handle(playback_nearly_finished_request)
+        response = app.handle(playback_nearly_finished_request)
+        assert response.get("sessionAttributes") == {}
+        assert response.get("response") == {"shouldEndSession": True}
 
     def test_playback_finished(self, app, mock_session_backend, playback_finished_request):
-        with pytest.raises(SystemExit):
-            app.handle(playback_finished_request)
+        response = app.handle(playback_finished_request)
+        assert response.get("sessionAttributes") == {}
+        assert response.get("response") == {"shouldEndSession": True}
 
     def test_session_cleared_and_saved(self, app, mock_session, launch_request):
         mock_session.is_expired = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -102,16 +102,16 @@ class TestInitialState(object):
 
     def test_playback_started(self, app, mock_session_backend, playback_started_request):
         response = app.handle(playback_started_request)
-        assert response is None
+        assert response == {}
 
     def test_playback_nearly_finished(self, app, mock_session_backend,
             playback_nearly_finished_request):
         response = app.handle(playback_nearly_finished_request)
-        assert response is None
+        assert response == {}
 
     def test_playback_finished(self, app, mock_session_backend, playback_finished_request):
         response = app.handle(playback_finished_request)
-        assert response is None
+        assert response == {}
 
     def test_session_cleared_and_saved(self, app, mock_session, launch_request):
         mock_session.is_expired = True


### PR DESCRIPTION
Why
---

- All of a sudden we started seeing errors from Amazon when we didn't
  return responses for certain events
- Amazon support suggests we return an empty json payload/dict rather
  than `None`
- The Alexa platform now throws an error if you send any response at all
to an `AudioPlayer.PlaybackStopped` intent.

This change addresses the need by
---------------------------------

- Raising a `SystemExit` instead of returning a response when the
response for an intent is `None` or `null`.
